### PR TITLE
[Feat] progressbar 공통 컴포넌트 제작

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,12 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="PercentageProgressBarPreview">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="ProgressBarPreview">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/example/rememory/ui/components/ProgressBar.kt
+++ b/app/src/main/java/com/example/rememory/ui/components/ProgressBar.kt
@@ -1,0 +1,2 @@
+package com.example.rememory.ui.components
+

--- a/app/src/main/java/com/example/rememory/ui/components/ProgressBar.kt
+++ b/app/src/main/java/com/example/rememory/ui/components/ProgressBar.kt
@@ -1,2 +1,65 @@
 package com.example.rememory.ui.components
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.rememory.ui.theme.PurplePrimary
+
+@Composable
+fun ProgressBar(
+    progress: Float,
+    modifier: Modifier = Modifier,
+    activeColor: Color = PurplePrimary,
+    trackColor: Color = Color(0xFFE5E7EB),
+    height: Dp = 10.dp
+) {
+    val animatedProgress by animateFloatAsState(targetValue = progress)
+
+    Box(modifier = modifier.fillMaxWidth()) {
+        // Track
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(height)
+                .clip(RoundedCornerShape(height / 2))
+                .background(trackColor)
+        )
+
+        // Active Indicator
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(fraction = animatedProgress)
+                .height(height)
+                .clip(RoundedCornerShape(height / 2))
+                .background(activeColor)
+        )
+    }
+}
+@Preview(showBackground = true)
+@Composable
+fun ProgressBarPreview(){
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+    ){
+        Text("Progress 70%")
+        Spacer(modifier = Modifier.padding(16.dp))
+        ProgressBar(progress = 0.7f)
+    }
+}


### PR DESCRIPTION
<!-- [제목] title ex) [feat] 소셜 로그인 기능 추가 -->

## [Feat] progressbar 공통 컴포넌트 제작

해당 이슈 번호
closed #4 

---


## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->
- compose에 기본으로 `linear progress bar indicator` 가 있지만, 이것을 사용하면 
1. 출발점과 목적지(destination)에 dot이 자동으로 표시되고, 
2. active indicator(진행 중 바)와 track(남은 바)이 4픽셀? 정도 떨어져있어서 
- `linear progress bar indicator`을 선택하지 않고 직접 구현했습니다.
---

## 📌스크린샷 (선택)
### 사용방법 예시
`ProgressBar(progress = 0.7f)` 이렇게 진행 상황을 퍼센테이지로 넣어주면 됩니다.

<img width="246" height="52" alt="스크린샷 2025-11-11 오후 4 03 18" src="https://github.com/user-attachments/assets/38c6c610-cfaf-462d-9277-09cac55c8622" />

